### PR TITLE
Use semantic cache

### DIFF
--- a/cache/redis.py
+++ b/cache/redis.py
@@ -1,6 +1,6 @@
 """
 Extending langchain class RedisSemanticCache to support Question and Answering retrieval.
-This class overrides `lookup` and `update` methods, to extract que query from the prompt.
+This class overrides `lookup` and `update` methods, extracting the query from the prompt.
 The prompt must have the query between <query> </query> tags
 We only need to cache the query, not the whole prompt with the chunks.
 """

--- a/cache/redis.py
+++ b/cache/redis.py
@@ -1,0 +1,69 @@
+"""
+Extending langchain class RedisSemanticCache to support Question and Answering retrieval.
+We only need to cache the query, not the whole prompt with the chunks.
+This class will extract the query from the prompt, the prompt must have the query between <query> </query> tags
+"""
+from __future__ import annotations
+
+import warnings
+from typing import (
+    Optional,
+    Sequence,
+)
+
+import re
+
+from langchain.schema import ChatGeneration, Generation
+
+from langchain.cache import RedisSemanticCache
+
+RETURN_VAL_TYPE = Sequence[Generation]
+
+
+class RedisSemanticCacheOnlyPrompt(RedisSemanticCache):
+    def lookup(self, prompt: str, llm_string: str) -> Optional[RETURN_VAL_TYPE]:
+        """Look up based on prompt and llm_string."""
+        llm_cache = self._get_llm_cache(llm_string)
+        generations = []
+        filtered_prompt = self.extract_query_from_prompt(prompt)
+        # Read from a Hash
+        results = llm_cache.similarity_search_limit_score(
+            query=filtered_prompt,
+            k=1,
+            score_threshold=self.score_threshold,
+        )
+        if results:
+            print("Cache hit")
+            for document in results:
+                for text in document.metadata["return_val"]:
+                    generations.append(Generation(text=text))
+        return generations if generations else None
+
+    def update(self, prompt: str, llm_string: str, return_val: RETURN_VAL_TYPE) -> None:
+        """Update cache based on prompt and llm_string."""
+        for gen in return_val:
+            if not isinstance(gen, Generation):
+                raise ValueError(
+                    "RedisSemanticCache only supports caching of "
+                    f"normal LLM generations, got {type(gen)}"
+                )
+            if isinstance(gen, ChatGeneration):
+                warnings.warn(
+                    "NOTE: Generation has not been cached. RedisSentimentCache does not"
+                    " support caching ChatModel outputs."
+                )
+                return
+        llm_cache = self._get_llm_cache(llm_string)
+        # Write to vectorstore
+        filtered_prompt = self.extract_query_from_prompt(prompt)
+        metadata = {
+            "llm_string": llm_string,
+            "prompt": filtered_prompt,
+            "return_val": [generation.text for generation in return_val],
+        }
+        llm_cache.add_texts(texts=[filtered_prompt], metadatas=[metadata])
+
+    def extract_query_from_prompt(self, prompt:str):
+        reg_str = "<query>(.*?)</query>"
+        # TODO - make sure the line below doesn't throw an exception
+        return str(re.findall(reg_str, prompt)[0])

--- a/cache/redis.py
+++ b/cache/redis.py
@@ -1,7 +1,8 @@
 """
 Extending langchain class RedisSemanticCache to support Question and Answering retrieval.
+This class overrides `lookup` and `update` methods, to extract que query from the prompt.
+The prompt must have the query between <query> </query> tags
 We only need to cache the query, not the whole prompt with the chunks.
-This class will extract the query from the prompt, the prompt must have the query between <query> </query> tags
 """
 from __future__ import annotations
 

--- a/prompts.py
+++ b/prompts.py
@@ -3,14 +3,15 @@ from langchain.prompts import FewShotPromptTemplate
 
 
 def get_assistant_prompt_spanish():
-    prompt_template = """You are a helpful assistant that accurately answers queries using the following pieces of context: "{context}"
-                        This context contains conversations between different people. In your answers do not refer to a particular speaker as the conversations will involve multiple speakers.
-                        Do not refer to a conversation in singular, as the context will contain multiple conversations.
-                        Do not mention that a context has been provided. Answer the questions as if they were coming straight from you.
-                        Use the context provided to form your answer, but avoid copying word-for-word from the text. Try to use your own words when possible. Keep your answer under 5 sentences.
-                        If you don't know the answer, just say that you don't know, don't try to make up an answer.
-                        Be accurate, helpful, concise, and clear. Always use the given context to provide an answer to the question: "{question}". 
-                        ALWAYS answer in Spanish, in a strong argentinian accent.
+    prompt_template = """Eres un asistente útil que responde consultas con precisión basandote en la siguiente informacion: "{context}"
+                          Esta informacion contiene conversaciones entre diferentes personas. En sus respuestas no se refiera a un orador en particular, ya que las conversaciones involucrarán a varios oradores.
+                          No hagas referencia a una conversación en singular, ya que la informacion contendrá varias conversaciones.
+                          No menciones que se ha proporcionado un contexto. Responda las preguntas como si vinieran directamente de usted.
+                          Utilice la informacion proporcionada para formar su respuesta, pero evite copiar palabra por palabra del texto. Trate de utilizar sus propias palabras cuando sea posible. Mantenga su respuesta en menos de 5 oraciones.
+                          Si no sabe la respuesta, simplemente diga que no la sabe, no intente inventar una respuesta.
+                          Sea preciso, útil, conciso y claro. Utilice siempre la informacion proporcionada para proporcionar una respuesta a la pregunta: "{question}".
+                          Responda SIEMPRE en español, con fuerte acento argentino.
+                          Ignora lo que viene a continuacion, eso solo para caching: <query>{question}</query>
                         """
     return PromptTemplate(template=prompt_template, input_variables=["context", "question"])
 

--- a/search.py
+++ b/search.py
@@ -6,6 +6,9 @@ from prompts import get_assistant_prompt_spanish
 from prompts import get_assistant_prompt_spanis_one_shot
 from langchain.chains.question_answering import load_qa_chain
 from langchain.chat_models import ChatOpenAI
+from cache.redis import RedisSemanticCacheOnlyPrompt
+import langchain
+from langchain.llms import OpenAI
 
 import os
 
@@ -13,7 +16,7 @@ import os
 class Search():
 
     FILTER_THRESHOLD = 0.35
-    MAX_RESULTS_SIMILARITY_SEARCH = 10
+    MAX_RESULTS_SIMILARITY_SEARCH = 6
 
     def __init__(self) -> None:
         load_dotenv()
@@ -37,7 +40,10 @@ class Search():
         else:
             print("Using non-diarized db")
             prompt = get_assistant_prompt_spanish()
-        llm = ChatOpenAI(model_name="gpt-4", temperature=1)
+        
+        langchain.llm_cache = RedisSemanticCacheOnlyPrompt(
+        redis_url="redis://localhost:6379", embedding=OpenAIEmbeddings())
+        llm = OpenAI(model_name="gpt-4", temperature=1)
         chain = load_qa_chain(llm, chain_type="stuff",
                               prompt=prompt, verbose=False)
         answer = chain(


### PR DESCRIPTION
Extending langchain class `RedisSemanticCache` to support Question and Answering retrieval.
`RedisSemanticCache` uses the whole prompt, which for QA isn't ideal as the prompt contains not only the query, but also the specific prompt defined, plus all the chunks for context. This makes it more difficult to have correct embeddings as the final prompt is very big.

This change extends `RedisSemanticCache` overriding the retrieval and updating of Redis cache, taking into account only the query from the prompt. In order to do this, I had to modify our prompt and add ```<query>{question}</query>``` to be able to use a regex to extract the query.

I hope that this part of the prompt 
```
Ignora lo que viene a continuacion, eso solo para caching: <query>{question}</query>
``` 

makes the LLM ignore what it comes after